### PR TITLE
Fix issue #38 for check_cron_runtime.py

### DIFF
--- a/src/check_cron_runtime.py
+++ b/src/check_cron_runtime.py
@@ -92,7 +92,7 @@ def main(verbose=False):
         exit(int(ok_code))
 
     cron_child_list = []
-    cron_child_time = []
+    cron_child_time = None
 
     for child in cron_childs.split('\n'):
         cron_child_list.append(child)
@@ -110,7 +110,7 @@ def main(verbose=False):
                 pass
 
             #check for 1 hour time
-            if int(cron_child_time) > 3600:
+            if cron_child_time and int(cron_child_time) > 3600:
                 # Check if cron name is on ignore list
                 include = True
                 child_pid = execute('pgrep -P ' + pid).strip()


### PR DESCRIPTION
Fixing possible `TypeError` with:
`int() argument must be a string or a number, not 'list'`
by assigning `cron_child_time` with `None` and checking for value
before trying to cast it to int.