### PR TITLE
Fix issue #38 for check_cron_runtime.py

### DIFF
--- a/src/check_cron_runtime.py
+++ b/src/check_cron_runtime.py
@@ -109,8 +109,11 @@ def main(verbose=False):
             except AttributeError:
                 pass
 
+            if not cron_child_time:
+                continue
+
             #check for 1 hour time
-            if cron_child_time and int(cron_child_time) > 3600:
+            if int(cron_child_time) > 3600:
                 # Check if cron name is on ignore list
                 include = True
                 child_pid = execute('pgrep -P ' + pid).strip()


### PR DESCRIPTION
Fixing possible `TypeError` with:
`int() argument must be a string or a number, not 'NoneType'` by first
checking if `cron_child_time` is None and if just continue the loop.