### PR TITLE
Move check target to /var/run/puppet_lastupdate

### DIFF
--- a/src/check_puppetd
+++ b/src/check_puppetd
@@ -18,7 +18,7 @@ case `uname` in
 		puppet_disabled_file="/var/lib/nagios3/.nopuppetd"
 		;;
 	Linux)
-		puppet_state_file="/var/lib/puppet/lastupdate"
+		puppet_state_file="/var/run/puppet_lastupdate"
 		puppet_disabled_file="/var/lib/nagios3/.nopuppetd"
 		;;
 esac
@@ -59,4 +59,3 @@ date_diff=$(( $date_cur - $date_puppet ))
     echo "WARNING - $date_diff sec."
     exit 1
 }
-


### PR DESCRIPTION
For puppet-agent version 1.10 on debian stretch the folder layout
changes. To keep the check compatible with jessie and stretch it is
advisable to target it to /var/run/puppet_lastupdate, and create
the neccessary file there.