### PR TITLE
Change location to persistent place

### DIFF
--- a/src/check_puppetd
+++ b/src/check_puppetd
@@ -18,7 +18,7 @@ case `uname` in
 		puppet_disabled_file="/var/lib/nagios3/.nopuppetd"
 		;;
 	Linux)
-		puppet_state_file="/var/run/puppet_lastupdate"
+		puppet_state_file="/var/tmp/puppet_lastupdate"
 		puppet_disabled_file="/var/lib/nagios3/.nopuppetd"
 		;;
 esac


### PR DESCRIPTION
/var/run gets deleted on reboot. According to:
http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s15.html
/var/tmp is the right place