### PR TITLE
Migrations for upcoming Gitlab update

### DIFF
--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -152,8 +152,7 @@ def main(args):
         if branch and
         (
             not branch['protected'] or
-            branch['developers_can_merge'] or
-            branch['developers_can_push']
+            branch['developers_can_merge'] or branch['developers_can_push']
         )
     ]
 

--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -115,6 +115,7 @@ def main(args):
     else:
         projects = fetch_projects(base_url, api, args.project, auth=auth)
 
+    projects = list(filter(None, projects))
     if not projects:
         print('No projects found')
         exit(3)

--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -106,14 +106,14 @@ def main(args):
         exit(3)
 
     if args.group:
-        projects = fetch_group_projects(base_url, args.group, args.project,
-                                        auth=auth)
+        projects = fetch_group_projects(base_url, api, args.group,
+                                        args.project, auth=auth)
     elif (args.project and
           # if args.project represents an int or is like 'group/project'
           ('/' in args.project or str(int(args.project)) == args.project)):
-        projects = [fetch_project(base_url, args.project, auth=auth)]
+        projects = [fetch_project(base_url, api, args.project, auth=auth)]
     else:
-        projects = fetch_projects(base_url, args.project, auth=auth)
+        projects = fetch_projects(base_url, api, args.project, auth=auth)
 
     if not projects:
         print('No projects found')
@@ -132,7 +132,7 @@ def main(args):
         if not branch:
             continue
         branch_requests.append(get_branch_request(
-            base_url, project['id'], branch, auth=auth))
+            base_url, api, project['id'], branch, auth=auth))
 
     # map the branch responses with their project
     branches = zip(
@@ -217,7 +217,7 @@ def fetch_api_version(base_url, auth=None):
     return None
 
 
-def fetch_project(base_url, project, auth=None):
+def fetch_project(base_url, api, project, auth=None):
     """
         :return: project
         :rtype: dict
@@ -225,8 +225,8 @@ def fetch_project(base_url, project, auth=None):
     if not project:
         return None
     project = quote(str(project), '')
-    endpoint = ('/api/v3/projects/{project}'
-                .format(project=project))
+    endpoint = ('/api/{api}/projects/{project}'
+                .format(api=api, project=project))
     response = do_request('get', base_url, endpoint, auth=auth)
     if response.status_code != 200:
         return None
@@ -235,12 +235,12 @@ def fetch_project(base_url, project, auth=None):
     return response
 
 
-def fetch_projects(base_url, search=None, auth=None):
+def fetch_projects(base_url, api, search=None, auth=None):
     """
         :return: projects
         :rtype: list of dict
     """
-    endpoint = '/api/v3/projects'
+    endpoint = '/api/{api}/projects'.format(api=api)
     params = {}
     if search:
         params['search'] = search
@@ -252,7 +252,7 @@ def fetch_projects(base_url, search=None, auth=None):
     return response
 
 
-def fetch_group_projects(base_url, group, project=None, auth=None):
+def fetch_group_projects(base_url, api, group, project=None, auth=None):
     """
         :return: projects
         :rtype: list of dict
@@ -260,8 +260,8 @@ def fetch_group_projects(base_url, group, project=None, auth=None):
     if not group:
         return None
     group = quote(str(group), '')
-    endpoint = ('/api/v3/groups/{group}/projects'
-                .format(group=group))
+    endpoint = ('/api/{api}/groups/{group}/projects'
+                .format(api=api, group=group))
     params = {}
     if project:
         params['search'] = project
@@ -273,13 +273,13 @@ def fetch_group_projects(base_url, group, project=None, auth=None):
     return response
 
 
-def get_branch_request(base_url, project, branch, auth=None):
+def get_branch_request(base_url, api, project, branch, auth=None):
     if not project or not branch:
         return None
     project = quote(str(project), '')
     branch = quote(str(branch), '')
-    endpoint = ('/api/v3/projects/{project}/repository/branches/{branch}'
-                .format(project=project, branch=branch))
+    endpoint = ('/api/{api}/projects/{project}/repository/branches/{branch}'
+                .format(api=api, project=project, branch=branch))
     return get_request('get', base_url, endpoint, auth=auth)
 
 

--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -191,6 +191,18 @@ def parse_auth_argument(args):
     return auth
 
 
+def fetch_api_version(base_url, auth=None):
+    versions = ('v3', 'v4')
+    for version in reversed(versions):
+        endpoint = '/api/{api}/version'.format(api=version)
+        response = do_request('head', base_url, endpoint, auth=auth)
+
+        if response.ok:
+            return version
+
+    return None
+
+
 def fetch_project(base_url, project, auth=None):
     """
         :return: project

--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -83,6 +83,12 @@ def parse_args():
     parser.add_argument('--branch',
                         help='the branch which should be protected, '
                              'default is the default branch of the project')
+    parser.add_argument(
+        '--api-version',
+        help=('The api version in form of "v3".  If not specified the script '
+              'tries to fetch current api version through the gitlab version '
+              'endpoint.  Right now it will try from api version 4 down to 3.')
+    )
     return parser.parse_args()
 
 
@@ -90,6 +96,14 @@ def main(args):
     base_url = args.base_url
 
     auth = parse_auth_argument(args)
+
+    api = args.api_version
+    if not api:
+        api = fetch_api_version(base_url, auth=auth)
+
+    if not api:
+        print('Api version could not be found.')
+        exit(3)
 
     if args.group:
         projects = fetch_group_projects(base_url, args.group, args.project,

--- a/src/gitlab_unprotected_branches.py
+++ b/src/gitlab_unprotected_branches.py
@@ -53,7 +53,8 @@ from requests.utils import quote
 
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument('--base-url',
+    # todo: make --base-url a positional argument
+    parser.add_argument('--base-url', required=True,
                         help='the base url of the application you want to '
                              'check (e.g. https://sub.example.com)')
     parser.add_argument('--auth', choices=('basic', 'token'),


### PR DESCRIPTION
Script has a new argument called `api-version` with which the user can specify the api version.  If not specified the script will try to determine the api version by trying to reach certain endpoints.

All other endpoints which are used in the script should still work.

So the PR can directly be merged, as it will support both api versions: `v3` and the upcoming `v4`.