### PR TITLE
Check if 'maintenanceExpiryDate' key exists

### DIFF
--- a/src/atlassian_expiring_licenses.py
+++ b/src/atlassian_expiring_licenses.py
@@ -109,8 +109,10 @@ def main(args):
     expires = [
         (plugin, response.json())
         for plugin, response in responses
-        if response and datetime.utcfromtimestamp(
-            response.json()['maintenanceExpiryDate'] / 1000) < deadline
+        if response and 'maintenanceExpiryDate' in response.json()
+        and datetime.utcfromtimestamp(
+            response.json()['maintenanceExpiryDate'] / 1000
+        ) < deadline
     ]
 
     if not expires:

--- a/src/atlassian_expiring_licenses.py
+++ b/src/atlassian_expiring_licenses.py
@@ -106,14 +106,22 @@ def main(args):
             for plugin in plugins)
     )
 
-    expires = [
-        (plugin, response.json())
-        for plugin, response in responses
-        if response and 'maintenanceExpiryDate' in response.json()
-        and datetime.utcfromtimestamp(
-            response.json()['maintenanceExpiryDate'] / 1000
-        ) < deadline
-    ]
+    expires = []
+    for plugin, response in responses:
+        if not response:
+            continue
+
+        json = response.json()
+        if 'maintenanceExpiryDate' not in json:
+            continue
+
+        expire_time = datetime.utcfromtimestamp(
+            json['maintenanceExpiryDate'] / 1000
+        )
+        if not expire_time < deadline:
+            continue
+
+        expires.append((plugin, json))
 
     if not expires:
         print('OK: No license will expire soon')


### PR DESCRIPTION
Script broke as there was a plugin which seems to use licensing however
has no information about the maintenance expiry date.  Therefore the
script will now check for the key before it continues the process.