### PR TITLE
check_process_list.py: Improve CPU time scaling

### DIFF
--- a/src/check_process_list.py
+++ b/src/check_process_list.py
@@ -315,11 +315,8 @@ class Process(dict):
             return None
 
         diff = value - self.prev_values[var]
-        if isinstance(diff, timedelta):
-            # TODO: Don't use .total_seconds()
-            diff = int(diff.total_seconds())
 
-        return (divider * diff) / int((self.ts - self.prev_ts).total_seconds())
+        return diff * (divider / (self.ts - self.prev_ts))
 
     def update_prev_value(self, var):
         filename = '/tmp/check_process_list_{}_{}'.format(self['pid'], var)


### PR DESCRIPTION
The `timedelta` object on Python2 doesn't support division.  Because of that I had to cast the both sides to `int` which harms precision and causes `DivisionByZero` when the script is called again quickly.  We can improve this and made the code cleaner once we don't support Python 2 anymore.
