### PR TITLE
mysql: Fix processlist time sort with python3

### DIFF
--- a/igmonplugins/check_mysql_processes.py
+++ b/igmonplugins/check_mysql_processes.py
@@ -163,6 +163,9 @@ class Database:
             self.processes = self.execute('SHOW PROCESSLIST')
             # We need to sort the entries to let the check() function stop
             # searching early.
+            for process in self.processes:
+                if process['time'] is None:
+                    process['time'] == -float('inf')
             self.processes.sort(key=itemgetter('time'), reverse=True)
         return self.processes
 


### PR DESCRIPTION
In the processlist of mysql there might be initial connections visible,
which got time value of None. Python3 will throw an exception, so we set it
to inf float.