### PR TITLE
Don't return on first NSCA send failure

### DIFF
--- a/src/check_qemu_version.py
+++ b/src/check_qemu_version.py
@@ -225,6 +225,7 @@ def build_plugin_output(newer_doms, unknown_doms, nsca_result):
 
 
 def send_nsca(hosts, output):
+    result = True
     for monitor in hosts:
         nsca = Popen(
             [
@@ -239,9 +240,9 @@ def send_nsca(hosts, output):
         nsca.communicate(output.encode())
         returncode = nsca.wait()
         if returncode > 0:
-            return False
+            result = False
 
-    return True
+    return result
 
 
 def main():


### PR DESCRIPTION
On first NSCA send failure, the send_nsca function would return and not send any more results. This tackles that and allow it to send the rest of the results. 