### PR TITLE
Fix always returning critical on non OK checks in check_multiple.py

### DIFF
--- a/src/check_multiple.py
+++ b/src/check_multiple.py
@@ -44,7 +44,7 @@ for iterate_param, process in subs.iteritems():
     if process.returncode != 0:
         if process.returncode == 3:
             unknown = True
-        elif process.returncode < exit_code:
+        elif process.returncode > exit_code:
             exit_code = process.returncode
         message += '(' + iterate_param + '): ' + out + '\n'
 if exit_code == 0 and unknown:


### PR DESCRIPTION
Behaviour before:
Whenever one check in check_multiple returned something else than "OK", check_multiple would retun "CRITICAL"
Behavior now:
check multiple returns the worst state it finds in an individual check: CRITICAL > WARNING > UNKNOWN > OK