### PR TITLE
Treat the ConnectionRefusedError exception on check_https_domains

### DIFF
--- a/src/check_https_domains.py
+++ b/src/check_https_domains.py
@@ -80,8 +80,8 @@ def main():
     try:
         state, output = get_check_result(domains, args.ip)
     except ConnectionRefusedError:
-        output = 'WARNING - The host refused the connection'
-        state = 2
+        output = 'CRITICAL - The host refused the connection'
+        state = 1
 
     print(output)
     sys.exit(state)

--- a/src/check_https_domains.py
+++ b/src/check_https_domains.py
@@ -77,7 +77,12 @@ def main():
         print(message)
         sys.exit(3)
 
-    state, output = get_check_result(domains, args.ip)
+    try:
+        state, output = get_check_result(domains, args.ip)
+    except ConnectionRefusedError:
+        output = 'WARNING - The host refused the connection'
+        state = 2
+
     print(output)
     sys.exit(state)
 
@@ -91,6 +96,7 @@ def get_domains(domains):
 
 def fetch_cert_info(domain, ip):
     domain = domain.replace('*', 'www', 1)
+
     conn = ssl.create_connection((ip, 443))
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     with context.wrap_socket(conn, server_hostname=domain) as sock:
@@ -98,6 +104,7 @@ def fetch_cert_info(domain, ip):
             crypto.FILETYPE_PEM,
             ssl.DER_cert_to_PEM_cert(sock.getpeercert(True))
         )
+
     common_name = cert.get_subject().commonName
     not_after = parse_date(cert.get_notAfter().decode('utf-8'))
     remaining = not_after - datetime.now(tzutc())


### PR DESCRIPTION
In cases where a LBPool had no alive nodes behind it, this check would
return an exception because the LBPool would refuse the connection.
This PR fixes that problem by capturing the exception and returning
a proper message as well as an exit code.