### PR TITLE
Ignore system service units if auto restarting

### DIFF
--- a/src/check_systemd_units.py
+++ b/src/check_systemd_units.py
@@ -134,6 +134,17 @@ class SystemdUnit:
         '''
         Detects problems for a service unit
         '''
+
+        if (
+            self.unit_properties.ActiveState == 'activating' and
+            self.unit_properties.SubState == 'auto-restart'
+        ):
+            # Ignore service units that are currently restarting but only tell
+            # us if they are failed. This allows us to use systemd to restart
+            # services silently without raising a warning which requires no
+            # manual action.
+            return (Codes.OK, '')
+
         # Most probably, oneshot is related to some timer
         if self.type_properties.Type == 'oneshot':
             # See the man 5 systemd.service for ExecMainStatus and


### PR DESCRIPTION
We don't want to raise a warning if a system service unit is in state
activating and sub state auto-restarting because systemd can probably
fix it on its own and there is no manual action required.
If this restart would fail we would notice later when the unit is in
state failed.