### PR TITLE
Fix compatibility with old python versions

### DIFF
--- a/src/check_clickhouse.py
+++ b/src/check_clickhouse.py
@@ -341,7 +341,7 @@ class CheckClusters(Check):
             return unoptimized_query
 
         cond = '{} = {}'
-        conditions: List[str] = []
+        conditions = []  # type: List[str]
         for k in partition_keys:
             default = self._get_type_default(k['type'])
             if default is not None:


### PR DESCRIPTION
It causes SyntaxError on python 3.5 now

```
  File "/usr/lib/nagios/igmonplugins/check_clickhouse.py", line 344
    conditions: List[str] = []                                     
              ^                                                    
SyntaxError: invalid syntax                                        
```