### PR TITLE
Use proper defaults for Date and DateTime types

### DIFF
--- a/src/check_clickhouse.py
+++ b/src/check_clickhouse.py
@@ -373,8 +373,14 @@ class CheckClusters(Check):
                       'TINYTEXT', 'VARCHAR', 'IPv6',
                       'FixedString', 'String'}:
             return "''"
-        elif type in {'Date', 'DateTime', 'DateTime64', 'TIMESTAMP'}:
-            return 'now()'
+        elif type in {'Date'}:
+            # By rule of thumb, 1970-01-02 should be less popular, than
+            # 0000-00-00
+            return 'toDate(1)'
+        elif type in {'DateTime', 'DateTime64', 'TIMESTAMP'}:
+            # By rule of thumb, 1970-01-01 00:00:01 should be less popular,
+            # than 0000-00-00 00:00:00
+            return 'toDateTime(1)'
         else:
             return None
 

--- a/src/check_clickhouse.py
+++ b/src/check_clickhouse.py
@@ -374,12 +374,12 @@ class CheckClusters(Check):
                       'FixedString', 'String'}:
             return "''"
         elif type in {'Date'}:
-            # By rule of thumb, 1970-01-02 should be less popular, than
-            # 0000-00-00
+            # toDate(1) as 1970-01-02 should be less popular
+            # than 0000-00-00 (toDate(0))
             return 'toDate(1)'
         elif type in {'DateTime', 'DateTime64', 'TIMESTAMP'}:
-            # By rule of thumb, 1970-01-01 00:00:01 should be less popular,
-            # than 0000-00-00 00:00:00
+            # toDateTime(1) as 1970-01-01 00:00:01 should be less popular
+            # than 0000-00-00 00:00:00 (toDateTime(0))
             return 'toDateTime(1)'
         else:
             return None


### PR DESCRIPTION
In https://github.com/ClickHouse/ClickHouse/pull/10791/files comparison of Date and DateTime was fixed, and now it honestly checks the `WHERE` clause. Instead of a quick check, we have a huge selection now.

```
2020.05.25 11:02:50.397612 [ 14619 ] {378971ff-2cd1-4490-bf3a-ebdbbd5b1dd3} <Debug> graphite.data_lr (SelectExecutor): Selected 15 parts by date, 15 parts by key, 8031785 marks to read from 15 ranges
2020.05.25 11:02:50.397885 [ 14619 ] {378971ff-2cd1-4490-bf3a-ebdbbd5b1dd3} <Trace> graphite.data_lr (SelectExecutor): Reading approx. 2056136960 rows with 6 streams
```

This PR fixes it.

Description for `1`:

```
┌───────toDateTime(0)─┐
│ 0000-00-00 00:00:00 │
└─────────────────────┘
┌───────toDateTime(1)─┐
│ 1970-01-01 00:00:01 │
└─────────────────────┘
┌──toDate(0)─┐
│ 0000-00-00 │
└────────────┘
┌──toDate(1)─┐
│ 1970-01-02 │
└────────────┘
```