### PR TITLE
Fix the wrong level for non-active service units

### DIFF
--- a/src/check_systemd_units.py
+++ b/src/check_systemd_units.py
@@ -200,11 +200,12 @@ class SystemdUnit:
         else:
             if self.unit_properties.ActiveState != 'active':
                 return (
-                    self._warn_level, 'the service is inactive'
+                    self._crit_level, 'the service is inactive'
                 )
             if self.unit_properties.SubState == 'exited':
+                # Non one-shot services should not exit
                 return (
-                    self._warn_level, 'the service is exited'
+                    self._crit_level, 'the service is exited'
                 )
 
         return (Codes.OK, '')

--- a/src/check_systemd_units.py
+++ b/src/check_systemd_units.py
@@ -211,7 +211,7 @@ class SystemdUnit:
                     self._crit_level, 'the service is inactive'
                 )
             if self.unit_properties.SubState == 'exited':
-                # Non one-shot services should not exit
+                # Non oneshot services should not exit
                 return (
                     self._crit_level, 'the service is exited'
                 )

--- a/src/check_systemd_units.py
+++ b/src/check_systemd_units.py
@@ -161,6 +161,13 @@ class SystemdUnit:
             # services silently without raising a warning which requires no
             # manual action.
             return (Codes.OK, '')
+        if (
+            hasattr(self.unit_properties, 'ConditionResult') and
+            not self.unit_properties.ConditionResult
+        ):
+            # systemd on Debian Buster contains a lot of services in inactive
+            # state by "Condition*" parameters, it's fine to ignore them
+            return (Codes.OK, '')
 
         # Most probably, oneshot is related to some timer
         if self.type_properties.Type == 'oneshot':

--- a/src/check_systemd_units.py
+++ b/src/check_systemd_units.py
@@ -33,6 +33,7 @@ Copyright (c) 2020 InnoGames GmbH
 
 import logging
 from argparse import ArgumentParser
+from contextlib import ExitStack
 from datetime import datetime
 from sys import exit
 from time import time
@@ -482,4 +483,7 @@ def gen_output(results):
 
 
 if __name__ == '__main__':
-    main()
+    with ExitStack() as stack:
+        # Manager must unsubscribe from DBus when it finishes the work
+        stack.callback(systemd_manager.unsubscribe)
+        main()


### PR DESCRIPTION
It looks like during the latest refactoring the logic of crit/warn was messed up a little bit. Here is an example of running the master code against the branch one

```
$ /usr/bin/python3 /usr/lib/nagios/igmonplugins/check_systemd_units.py -u 'nginx.service'
OK
$ /usr/bin/python3 check_systemd_units.py -u 'nginx.service'
OK
$ sudo systemctl stop nginx
$ /usr/bin/python3 /usr/lib/nagios/igmonplugins/check_systemd_units.py -u 'nginx.service'
WARNING: the service is inactive: nginx.service
$ /usr/bin/python3 /usr/lib/nagios/igmonplugins/check_systemd_units.py -a -i proc-sys-fs-binfmt_misc.automount
OK
$ /usr/bin/python3 check_systemd_units.py -u 'nginx.service'
CRITICAL: the service is inactive: nginx.service
$ /usr/bin/python3 check_systemd_units.py -a
WARNING: the service is inactive: systemd-fsckd.service
```