### PR TITLE
Include hidden warnings too on Jenkins

### DIFF
--- a/src/check_plugin_vulnerability.py
+++ b/src/check_plugin_vulnerability.py
@@ -28,12 +28,20 @@ import argparse
 import requests
 from sys import exit
 
-SCRIPT = (
-    'def warnings_monitor = new jenkins.security.UpdateSiteWarningsMonitor()\n'  # NOQA E501 Don't wrap because of groovy code
-    'def plugin_vulnerabilities = warnings_monitor.getActivePluginWarningsByPlugin()\n'  # NOQA E501 Don't wrap because of groovy code
-    'def critical_plugins = plugin_vulnerabilities.keySet()*.longName\n'
-    'print(new groovy.json.JsonBuilder(critical_plugins))'
-)
+SCRIPT = """
+    import jenkins.security.*
+    ExtensionList<UpdateSiteWarningsConfiguration> configurations = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
+    UpdateSiteWarningsConfiguration configuration = configurations.get(0);
+    problematic_plugins = []
+    current_warnings = configuration.getApplicableWarnings()
+    current_warnings.each {
+        if (it.type.name() == 'PLUGIN') {
+            problematic_plugins.add(it.component)
+        }
+    }
+    print(new groovy.json.JsonBuilder(problematic_plugins.unique()))
+"""  # NOQA E501 Don't wrap because of groovy code
+
 IGNORE_FILE = '/etc/nagios-plugins/check_plugin_vulnerability_ignore'
 
 


### PR DESCRIPTION
Users can "ignore" some warnings on Jenkins management interface. We'd like to have our ignore file to be the only source of truth in this case. New groovy code doesn't care if user has ignored it on UI.