### PR TITLE
Exclude information_schema from being checked

### DIFF
--- a/src/check_mysql_table_status.py
+++ b/src/check_mysql_table_status.py
@@ -248,7 +248,9 @@ class Database(object):
 
     def get_table_values(self, attributes):
         """Iterate tables with selected attributes"""
-        for schema in self.select_one('SHOW SCHEMAS'):
+        for schema in self.select_one(
+            "SHOW SCHEMAS where `Database` != 'information_schema'"
+        ):
             rows = self.select(
                 'SHOW TABLE STATUS IN `{}` WHERE Engine IS NOT NULL'
                 .format(schema)


### PR DESCRIPTION
Bloated tables cant be debloated the usual way
for tables within information_schema, so we clean
up monitoring a bit by excluding them from being checked.