### PR TITLE
Fix no output message if everything is ok

### DIFF
--- a/src/check_sentryio_limits.py
+++ b/src/check_sentryio_limits.py
@@ -168,7 +168,7 @@ def main():
                   "in total")
 
     # If neither team nor organization limit is hit
-    elif exit == 0:
+    if exit == 0:
         print(f"OK: {organization['summed_events']} "
               "events are configured in total")
 


### PR DESCRIPTION
The "ok" message is not printed due to a wrong if statement.