### PR TITLE
Check domain of certificates to match

### DIFF
--- a/src/check_https_domains.py
+++ b/src/check_https_domains.py
@@ -134,6 +134,14 @@ def get_check_result(domains, ip, port, timeout):
     for domain in domains:
         try:
             cert_info = fetch_cert_info(domain, ip, port, timeout)
+            if cert_info['common_name'].startswith('*'):
+                if cert_info['common_name'].split('.')[1:] != \
+                        cert_info['domain'].split('.')[1:]:
+                    return(2, 'Certificate {} does not match domain {}'.format(
+                           cert_info['common_name'], cert_info['domain']))
+            elif cert_info['domain'] != cert_info['common_name']:
+                return(2, 'Certificate {} does not match domain {}'.format(
+                       cert_info['common_name'], cert_info['domain']))
             expirations.append(cert_info)
         except (socket.timeout, TimeoutError):
             return (3, 'The connection to the destination host timed out')

--- a/src/check_https_domains.py
+++ b/src/check_https_domains.py
@@ -29,11 +29,12 @@ from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_date
 from dateutil.tz import tzutc
 from OpenSSL import crypto
+from string import ascii_letters
+from random import choice 
 
 # Amount of days remaining before warning and critical states
 warn = 30
 crit = 2
-
 
 def parse_args():
     parser = ArgumentParser(
@@ -106,7 +107,8 @@ def get_domains(domains):
 
 
 def fetch_cert_info(domain, ip, port, timeout):
-    domain = domain.replace('*', 'www', 1)
+    rndpre = ''.join(choice(ascii_letters)  for i in range(20))
+    domain = domain.replace('*', rndpre, 1)
 
     conn = ssl.create_connection((ip, port), timeout)
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
Hacked a way to check the explicit or wildcard domain to match the CN field. SAN field are not taken into account and would need to be added to cover all cases. 