### PR TITLE
Fix type error in join()

### DIFF
--- a/src/check_seaweedfs.py
+++ b/src/check_seaweedfs.py
@@ -119,7 +119,7 @@ def _check_readonly_volumes(data: dict[str, Any]) -> int:
             for endpoint in server.values():
                 for volume in endpoint:
                     if volume['ReadOnly']:
-                        readonly_volumes.append(volume['Id'])
+                        readonly_volumes.append(str(volume['Id']))
 
     if readonly_volumes:
         volumes_str = ', '.join(readonly_volumes)


### PR DESCRIPTION
Looks like we can't do `str.join(list[int])` in Python, so we create a `list[str]`