### PR TITLE
seaweed: Re-word to clear ambiguity on warning

### DIFF
--- a/src/check_seaweedfs.py
+++ b/src/check_seaweedfs.py
@@ -127,7 +127,7 @@ def _check_readonly_volumes(data: dict[str, Any]) -> int:
 
     if readonly_volumes:
         volumes_str = ', '.join(readonly_volumes)
-        print(f'CRITICAL: Readonly volumes detected: {volumes_str}')
+        print(f'CRITICAL: Detected read-only volume IDs: {volumes_str}')
         return 2
 
     return 0


### PR DESCRIPTION
When it says `CRITICAL: Readonly volumes detected: 1059` people may understand there are 1059 read-only volumes :)