### PR TITLE
qemu_version: Handle KVM processes without domain

### DIFF
--- a/src/check_qemu_version.py
+++ b/src/check_qemu_version.py
@@ -115,14 +115,20 @@ def get_domain_list():
     for proc in psutil.process_iter():
         if proc.username() != 'libvirt-qemu':
             continue
-        vmname = list(filter(r.match, proc.cmdline()))[0]
-        if vmname:
-            domain = {
-                'pid':    proc.pid,
-                'vmname': r.search(vmname).group(2),
-                'hvname': hvname
-            }
-            domains.append(domain)
+
+        # If there are any kvm/qemu processes which are not a VM,
+        # the vmname receives an empty list and we skip to the next one.
+        vmname = list(filter(r.match, proc.cmdline()))
+        if not vmname:
+            continue
+
+        vmname = vmname[0]
+        domain = {
+            'pid':    proc.pid,
+            'vmname': r.search(vmname).group(2),
+            'hvname': hvname
+        }
+        domains.append(domain)
     return domains
 
 


### PR DESCRIPTION
The QMP monitor process is a kvm process, ran by the libvirt user that doesn't contain a domain name. This patch adjusts the logic to skip these processes.