### PR TITLE
check_switch: Update Cumulus switch identifier

### DIFF
--- a/src/check_switch.py
+++ b/src/check_switch.py
@@ -242,7 +242,7 @@ def get_switch_model(snmp):
         return 'extreme'
     elif 'Dell Networking OS' in model:
         return 'force10_mxl'
-    elif 'Cumulus-Linux' in model:
+    elif 'Cumulus' in model:
         return 'cumulus'
     elif 'EdgeSwitch' in model:
         return 'edgeswitch'


### PR DESCRIPTION
Cumulus 5.10 shows up as Cumulus-linux instead of Cumulus-Linux