### PR TITLE
Lower the fping amount to 9 pings

### DIFF
--- a/src/check_tunnels.py
+++ b/src/check_tunnels.py
@@ -73,7 +73,7 @@ def parse_args():
         help='Warning threshold for packet loss in percent')
     parser.add_argument('--critical-loss', type=int, default=50,
         help='Critical threshold for packet loss in percent')
-    parser.add_argument('--count', type=int, default=10,
+    parser.add_argument('--count', type=int, default=9,
         help='Count of pings to send')
     return parser.parse_args()
 


### PR DESCRIPTION
A default of 9 pings and thereby 9 seconds makes more sense for most nagios nrpe installations. As the default nrpe timeout is 10s an unreachable host would cause this check to fail with a nrpe timeout rather then the correct output of the unreachble target.