### PR TITLE
check_logrotate_missing: Properly handle wildcards from logrotate

### DIFF
--- a/src/check_logrotate_missing.py
+++ b/src/check_logrotate_missing.py
@@ -142,7 +142,8 @@ def check_logrotation_config(config, exclude):
             with open(conf) as in_file:
                 for line in in_file:
                     if line.startswith('/'):
-                        configured_logs.add(line.rstrip('{\n\t '))
+                        configured_logs.update(set(
+                            glob.glob(line.rstrip('{\n\t '))))
 
         log_dirs = {os.path.dirname(c) for c in configured_logs}
 


### PR DESCRIPTION
As of now the check_logrotate_missing does not respect configured wildcards, with that it's fixed