### PR TITLE
Do not execute psqlrc in psql commands

### DIFF
--- a/src/check_postgres_pgbouncer_requests.py
+++ b/src/check_postgres_pgbouncer_requests.py
@@ -96,7 +96,7 @@ def get_pgbouncer_requests(port, dbname, host):
     """
 
     output = subprocess.check_output(
-            'psql -p {} pgbouncer -h {} -Ac "show stats;"'.format(
+            'psql -p {} pgbouncer -h {} -XAc "show stats;"'.format(
                 port, host
             ), shell=True)
 

--- a/src/check_postgres_waiting_changes.py
+++ b/src/check_postgres_waiting_changes.py
@@ -54,7 +54,7 @@ def _get_configs_pending_restarts():
     query = "select name from pg_settings where pending_restart = 't';"
 
     output = subprocess.check_output(
-        'psql postgres -tAc "{}"'.format(query), shell=True)
+        'psql postgres -tXAc "{}"'.format(query), shell=True)
 
     return(output.decode().splitlines())
 


### PR DESCRIPTION
We would like to add some (non-silent) goodies to default psqlrc for convenience. And this disturbs the checks which does not ignore that file.