### PR TITLE
qemu_version: Adjust version parsing regex

### DIFF
--- a/src/check_qemu_version.py
+++ b/src/check_qemu_version.py
@@ -99,7 +99,7 @@ def execute(cmd):
 
 
 def parse_qemu_version(version):
-    r = re.compile(r'.*version\s([\d\.]+\s?\([\w\d\.\s:\+-]+\)).*')
+    r = re.compile(r'.*version\s([\d\.]+\s?\([\w\d\.\s:\+-~]+\)).*')
     match = r.match(version)
     # Return None if couldn't match string. Deal with None as couldn't
     # retrieve version.


### PR DESCRIPTION
We had to build a custom QEMU version that ended up with a `~ig`
appended to the version string. As the regex was missing the tilda, the
monitoring check is now failing to parse the version.