### PR TITLE
check_jenkins_remoting: Check for the jars we actually use

### DIFF
--- a/src/check_jenkins_remoting.py
+++ b/src/check_jenkins_remoting.py
@@ -8,6 +8,7 @@ on the host.  It looks for a java process with the specified jar file
 Copyright (c) 2026 InnoGames GmbH
 """
 
+import platform
 import sys
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE
@@ -19,8 +20,9 @@ def parse_args():
     )
     parser.add_argument(
         "--jar",
-        default="remoting.jar",
-        help="Jar filename to match (e.g. remoting.jar, slave.jar)",
+        nargs="+",
+        default=["remoting", "slave.jar"],
+        help="Jar name substrings to match (default: remoting slave.jar)",
     )
     parser.add_argument(
         "--critical",
@@ -30,7 +32,8 @@ def parse_args():
     return parser.parse_args()
 
 
-def main(args):
+def check_process(jars):
+    """Check for Jenkins remoting via ps output."""
     ps = Popen(("ps", "-A", "-o", "pid=", "-o", "command="), stdout=PIPE)
 
     with ps.stdout as fd:
@@ -39,9 +42,50 @@ def main(args):
             if len(parts) < 2:
                 continue
             pid, command = parts
-            if "java" in command and "-jar" in command and args.jar in command:
-                print(f"OK - Jenkins remoting process running (PID: {pid})")
-                sys.exit(0)
+            if "java" in command and "-jar" in command:
+                if any(jar in command for jar in jars):
+                    return pid
+    return None
+
+
+def check_launchd(jars):
+    """Check for Jenkins remoting via launchctl on macOS."""
+    launchctl = Popen(
+        ("launchctl", "list"),
+        stdout=PIPE,
+        stderr=PIPE,
+    )
+    with launchctl.stdout as fd:
+        for line in fd:
+            parts = line.decode("utf8").strip().split("\t")
+            if len(parts) < 3:
+                continue
+            pid, status, label = parts
+            if "jenkins" in label.lower() and pid != "-":
+                # Verify the service is actually running the expected jar
+                # by inspecting its arguments via launchctl print
+                print_proc = Popen(
+                    ("launchctl", "print", f"system/{label}"),
+                    stdout=PIPE,
+                    stderr=PIPE,
+                )
+                stdout, _ = print_proc.communicate()
+                output = stdout.decode("utf8", errors="replace")
+                if any(jar in output for jar in jars):
+                    return pid
+    return None
+
+
+def main(args):
+    pid = check_process(args.jar)
+
+    # On macOS, also check launchd services if process check fails
+    if pid is None and platform.system() == "Darwin":
+        pid = check_launchd(args.jar)
+
+    if pid is not None:
+        print(f"OK - Jenkins remoting process running (PID: {pid})")
+        sys.exit(0)
 
     if args.critical:
         print("CRITICAL - Jenkins remoting process not running")

--- a/src/check_jenkins_remoting.py
+++ b/src/check_jenkins_remoting.py
@@ -11,38 +11,38 @@ Copyright (c) 2026 InnoGames GmbH
 import platform
 import sys
 from argparse import ArgumentParser
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 
 
 def parse_args():
     parser = ArgumentParser(
-        description="Check if Jenkins remoting agent process is running",
+        description='Check if Jenkins remoting agent process is running',
     )
     parser.add_argument(
-        "--jar",
-        nargs="+",
-        default=["remoting", "slave.jar"],
-        help="Jar name substrings to match (default: remoting slave.jar)",
+        '--jar',
+        nargs='+',
+        default=['remoting', 'slave.jar'],
+        help='Jar name substrings to match (default: remoting slave.jar)',
     )
     parser.add_argument(
-        "--critical",
-        action="store_true",
-        help="Exit CRITICAL instead of WARNING when process is not found",
+        '--critical',
+        action='store_true',
+        help='Exit CRITICAL instead of WARNING when process is not found',
     )
     return parser.parse_args()
 
 
 def check_process(jars):
     """Check for Jenkins remoting via ps output."""
-    ps = Popen(("ps", "-A", "-o", "pid=", "-o", "command="), stdout=PIPE)
+    ps = Popen(('ps', '-A', '-o', 'pid=', '-o', 'command='), stdout=PIPE)
 
     with ps.stdout as fd:
         for line in fd:
-            parts = line.decode("utf8").strip().split(None, 1)
+            parts = line.decode('utf8').strip().split(None, 1)
             if len(parts) < 2:
                 continue
             pid, command = parts
-            if "java" in command and "-jar" in command:
+            if 'java' in command and '-jar' in command:
                 if any(jar in command for jar in jars):
                     return pid
     return None
@@ -51,26 +51,26 @@ def check_process(jars):
 def check_launchd(jars):
     """Check for Jenkins remoting via launchctl on macOS."""
     launchctl = Popen(
-        ("launchctl", "list"),
+        ('launchctl', 'list'),
         stdout=PIPE,
         stderr=PIPE,
     )
     with launchctl.stdout as fd:
         for line in fd:
-            parts = line.decode("utf8").strip().split("\t")
+            parts = line.decode('utf8').strip().split('\t')
             if len(parts) < 3:
                 continue
             pid, status, label = parts
-            if "jenkins" in label.lower() and pid != "-":
+            if 'jenkins' in label.lower() and pid != '-':
                 # Verify the service is actually running the expected jar
                 # by inspecting its arguments via launchctl print
                 print_proc = Popen(
-                    ("launchctl", "print", f"system/{label}"),
+                    ('launchctl', 'print', f'system/{label}'),
                     stdout=PIPE,
                     stderr=PIPE,
                 )
                 stdout, _ = print_proc.communicate()
-                output = stdout.decode("utf8", errors="replace")
+                output = stdout.decode('utf8', errors='replace')
                 if any(jar in output for jar in jars):
                     return pid
     return None
@@ -80,20 +80,20 @@ def main(args):
     pid = check_process(args.jar)
 
     # On macOS, also check launchd services if process check fails
-    if pid is None and platform.system() == "Darwin":
+    if pid is None and platform.system() == 'Darwin':
         pid = check_launchd(args.jar)
 
     if pid is not None:
-        print(f"OK - Jenkins remoting process running (PID: {pid})")
+        print(f'OK - Jenkins remoting process running (PID: {pid})')
         sys.exit(0)
 
     if args.critical:
-        print("CRITICAL - Jenkins remoting process not running")
+        print('CRITICAL - Jenkins remoting process not running')
         sys.exit(2)
     else:
-        print("WARNING - Jenkins remoting process not running")
+        print('WARNING - Jenkins remoting process not running')
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main(parse_args())


### PR DESCRIPTION
Makes it a bit more mac-friendly with checking launchctl directly.